### PR TITLE
Add seurat conversion

### DIFF
--- a/bin/mtx_to_seurat.R
+++ b/bin/mtx_to_seurat.R
@@ -1,0 +1,25 @@
+#!/usr/bin/env Rscript
+library(Seurat)
+
+args <- commandArgs(trailingOnly=TRUE)
+
+mtx_file     <- args[1]
+barcode_file <- args[2]
+feature_file <- args[3]
+out.file     <- args[4]
+aligner      <- args[5]
+
+if(aligner %in% c("kallisto", "alevin")) {
+  # for kallisto and alevin, the features file contains only one column and matrix needs to be transposed
+  expression.matrix <- ReadMtx(
+    mtx = mtx_file, features = feature_file, cells = barcode_file, feature.column = 1, mtx.transpose = TRUE
+  )
+} else {
+  expression.matrix <- ReadMtx(
+    mtx = mtx_file, features = feature_file, cells = barcode_file
+  )
+}
+
+seurat.object <- CreateSeuratObject(counts = expression.matrix)
+
+saveRDS(seurat.object, file = out.file)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -55,15 +55,15 @@ if(params.aligner == "cellranger") {
                 mode: params.publish_dir_mode
             ]
         }
-        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        // withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        //     publishDir = [
+        //         path: { "${params.outdir}/cellranger/count/sample-${meta.id}/outs/filtered_feature_bc_matrix" },
+        //         mode: params.publish_dir_mode
+        //     ]
+        // }
+        withName: 'CONCAT_H5AD|MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
-                path: { "${params.outdir}/cellranger/count/sample-${meta.id}/outs/filtered_feature_bc_matrix" },
-                mode: params.publish_dir_mode
-            ]
-        }
-        withName: CONCAT_H5AD {
-            publishDir = [
-                path: { "${params.outdir}/cellranger/count/concatenated_h5ad" },
+                path: { "${params.outdir}/cellranger/count/h5ad_conversions" },
                 mode: params.publish_dir_mode
             ]
         }
@@ -76,15 +76,15 @@ if (params.aligner == "alevin") {
             ext.args = "--table transcript_id,gene_id"
             ext.prefix = { "${gff.baseName}_gffread" }
         }
-        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        // withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        //     publishDir = [
+        //         path: { "${params.outdir}/salmon/${meta.id}_alevin_results/alevin" },
+        //         mode: params.publish_dir_mode
+        //     ]
+        // }
+        withName: 'CONCAT_H5AD|MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
-                path: { "${params.outdir}/salmon/${meta.id}_alevin_results/alevin" },
-                mode: params.publish_dir_mode
-            ]
-        }
-        withName: CONCAT_H5AD {
-            publishDir = [
-                path: { "${params.outdir}/salmon/concatenated_h5ad" },
+                path: { "${params.outdir}/salmon/h5ad_conversions" },
                 mode: params.publish_dir_mode
             ]
         }
@@ -101,15 +101,15 @@ if (params.aligner == "star") {
 
 if (params.aligner == "kallisto") {
     process {
-        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        // withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
+        //     publishDir = [
+        //         path: { "${params.outdir}/kallistobustools/${meta.id}_kallistobustools_count/counts_unfiltered" },
+        //         mode: params.publish_dir_mode
+        //     ]
+        // }
+        withName: 'CONCAT_H5AD|MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
-                path: { "${params.outdir}/kallistobustools/${meta.id}_kallistobustools_count/counts_unfiltered" },
-                mode: params.publish_dir_mode
-            ]
-        }
-        withName: CONCAT_H5AD {
-            publishDir = [
-                path: { "${params.outdir}/kallistobustools/concatenated_h5ad" },
+                path: { "${params.outdir}/kallistobustools/h5ad_conversions" },
                 mode: params.publish_dir_mode
             ]
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -55,7 +55,7 @@ if(params.aligner == "cellranger") {
                 mode: params.publish_dir_mode
             ]
         }
-        withName: MTX_TO_H5AD {
+        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
                 path: { "${params.outdir}/cellranger/count/sample-${meta.id}/outs/filtered_feature_bc_matrix" },
                 mode: params.publish_dir_mode
@@ -76,7 +76,7 @@ if (params.aligner == "alevin") {
             ext.args = "--table transcript_id,gene_id"
             ext.prefix = { "${gff.baseName}_gffread" }
         }
-        withName: MTX_TO_H5AD {
+        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
                 path: { "${params.outdir}/salmon/${meta.id}_alevin_results/alevin" },
                 mode: params.publish_dir_mode
@@ -101,7 +101,7 @@ if (params.aligner == "star") {
 
 if (params.aligner == "kallisto") {
     process {
-        withName: MTX_TO_H5AD {
+        withName: 'MTX_TO_H5AD|MTX_TO_SEURAT' {
             publishDir = [
                 path: { "${params.outdir}/kallistobustools/${meta.id}_kallistobustools_count/counts_unfiltered" },
                 mode: params.publish_dir_mode

--- a/modules/local/mtx_to_seurat.nf
+++ b/modules/local/mtx_to_seurat.nf
@@ -1,0 +1,46 @@
+process MTX_TO_SEURAT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda (params.enable_conda ? "seurat-scripts" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://satijalab/seurat:4.1.0' :
+        'satijalab/seurat:4.1.0' }"
+
+    input:
+    // inputs from cellranger nf-core module does not come in a single sample dir
+    // for each sample, the sub-folders and files come directly in array.
+    tuple val(meta), path(inputs)
+
+    output:
+    path "*.seurat", emit: h5ad
+
+    script:
+    def aligner = params.aligner
+    if (params.aligner == "cellranger") {
+        matrix   = "filtered_feature_bc_matrix/matrix.mtx.gz"
+        barcodes = "filtered_feature_bc_matrix/barcodes.tsv.gz"
+        features = "filtered_feature_bc_matrix/features.tsv.gz"
+    } else if (params.aligner == "kallisto") {
+        matrix   = "*_kallistobustools_count/counts_unfiltered/*.mtx"
+        barcodes = "*_kallistobustools_count/counts_unfiltered/*.barcodes.txt"
+        features = "*_kallistobustools_count/counts_unfiltered/*.genes.txt"
+    } else if (params.aligner == "alevin") {
+        matrix   = "*_alevin_results/alevin/quants_mat.mtx.gz"
+        barcodes = "*_alevin_results/alevin/quants_mat_rows.txt"
+        features = "*_alevin_results/alevin/quants_mat_cols.txt"
+    }
+    """
+    mtx_to_seurat.R \\
+        $matrix \\
+        $barcodes \\
+        $features \\
+        ${meta.id}_matrix.seurat \\
+        ${aligner}
+    """
+
+    stub:
+    """
+    touch ${meta.id}_matrix.h5ad
+    """
+}

--- a/subworkflows/local/mtx_conversion.nf
+++ b/subworkflows/local/mtx_conversion.nf
@@ -1,8 +1,9 @@
 /* --    IMPORT LOCAL MODULES/SUBWORKFLOWS     -- */
-include { MTX_TO_H5AD }             from '../../modules/local/mtx_to_h5ad.nf'
-include { CONCAT_H5AD }             from '../../modules/local/concat_h5ad.nf'
+include { MTX_TO_H5AD   }             from '../../modules/local/mtx_to_h5ad.nf'
+include { CONCAT_H5AD   }             from '../../modules/local/concat_h5ad.nf'
+include { MTX_TO_SEURAT }             from '../../modules/local/mtx_to_seurat.nf'
 
-workflow H5AD_CONVERSION {
+workflow MTX_CONVERSION {
 
     take:
     mtx_matrices
@@ -22,6 +23,13 @@ workflow H5AD_CONVERSION {
     CONCAT_H5AD (
         MTX_TO_H5AD.out.h5ad.collect(), // gather all sample-specific files
         samplesheet
+    )
+
+    //
+    // Convert matrix do seurat
+    //
+    MTX_TO_SEURAT (
+        mtx_matrices
     )
 
 }

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -40,7 +40,7 @@ include { KALLISTO_BUSTOOLS } from '../subworkflows/local/kallisto_bustools'
 include { SCRNASEQ_ALEVIN   } from '../subworkflows/local/alevin'
 include { STARSOLO          } from '../subworkflows/local/starsolo'
 include { CELLRANGER_ALIGN  } from "../subworkflows/local/align_cellranger"
-include { H5AD_CONVERSION   } from "../subworkflows/local/conversion_to_h5ad"
+include { MTX_CONVERSION   } from "../subworkflows/local/mtx_conversion"
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,7 +169,7 @@ workflow SCRNASEQ {
     }
 
     // Run mtx to h5ad conversion subworkflow
-    H5AD_CONVERSION (
+    MTX_CONVERSION (
         ch_mtx_matrices,
         ch_input
     )


### PR DESCRIPTION
This PR brings the addition of a new module that converts h5ad data to seurat objects.

It also puts conversion modules in a single subworkflow and now they are all outputted in a single folder to make it easy to find them after running.